### PR TITLE
Modernize golangci-lint config

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,27 +2,22 @@ version: "2"
 linters:
   default: standard
   enable:
+    - bodyclose
+    - prealloc
     - unparam
+  exclusions:
+    paths:
+      - generated.*\.go
+      - client
+      - vendor
 
 formatters:
   enable:
-    - gofmt
+    - gofumpt
     - goimports
-  settings:
-    gofmt:
-      rewrite-rules:
-        - pattern: 'interface{}'
-          replacement: 'any'
 
 issues:
   max-same-issues: 100
-
-  exclude-files:
-    - generated.*\\.go
-
-  exclude-dirs:
-    - client
-    - vendor
 
 run:
   timeout: 10m

--- a/apis/core/v1alpha1/restoresession_helpers_test.go
+++ b/apis/core/v1alpha1/restoresession_helpers_test.go
@@ -222,7 +222,8 @@ func TestAllComponentsCompletedIfAFailedComponentCanNeverBeFollowedByTheRest(t *
 
 func TestRestoreSessionPhaseIsFailedIfPreRestoreHooksExecutionSucceededConditionIsFalse(t *testing.T) {
 	rs := sampleRestoreSession(func(r *RestoreSession) {
-		r.Status.Conditions = append(r.Status.Conditions,
+		r.Status.Conditions = append(
+			r.Status.Conditions,
 			kmapi.Condition{
 				Type:   TypePreRestoreHooksExecutionSucceeded,
 				Status: metav1.ConditionFalse,
@@ -241,7 +242,8 @@ func TestRestoreSessionPhaseIsFailedIfPreRestoreHooksExecutionSucceededCondition
 
 func TestRestoreSessionPhaseIsFailedIfPostRestoreHooksExecutionSucceededConditionIsFalse(t *testing.T) {
 	rs := sampleRestoreSession(func(r *RestoreSession) {
-		r.Status.Conditions = append(r.Status.Conditions,
+		r.Status.Conditions = append(
+			r.Status.Conditions,
 			kmapi.Condition{
 				Type:   TypePostRestoreHooksExecutionSucceeded,
 				Status: metav1.ConditionFalse,
@@ -260,7 +262,8 @@ func TestRestoreSessionPhaseIsFailedIfPostRestoreHooksExecutionSucceededConditio
 
 func TestRestoreSessionPhaseIsFailedIfRestoreExecutorEnsuredConditionIsFalse(t *testing.T) {
 	rs := sampleRestoreSession(func(r *RestoreSession) {
-		r.Status.Conditions = append(r.Status.Conditions,
+		r.Status.Conditions = append(
+			r.Status.Conditions,
 			kmapi.Condition{
 				Type:   TypeRestoreExecutorEnsured,
 				Status: metav1.ConditionFalse,

--- a/pkg/blob/blob.go
+++ b/pkg/blob/blob.go
@@ -490,7 +490,8 @@ func (b *Blob) getS3Config(ctx context.Context, debug bool) (aws2.Config, error)
 
 	if debug {
 		loadOptions = append(loadOptions, config.WithClientLogMode(
-			aws2.LogRetries|aws2.LogRequestWithBody|aws2.LogResponseWithBody))
+			aws2.LogRetries|aws2.LogRequestWithBody|aws2.LogResponseWithBody,
+		))
 	}
 
 	if b.backupStorage.Spec.Storage.S3.SecretName != "" {

--- a/pkg/progress/status.go
+++ b/pkg/progress/status.go
@@ -112,7 +112,8 @@ func (pg *Progress) updateSnapshotComponentStatus(snap *storageapi.Snapshot, com
 			}
 			in.Status.Components[pg.component] = comp
 			return in
-		})
+		},
+	)
 	return err
 }
 


### PR DESCRIPTION
## Summary

Modernize the `.golangci.yml` configuration for golangci-lint v2 and switch the configured formatter to gofumpt.

This aligns the linter with the build image (`ghcr.io/appscode/golang-dev`), where `gofmt` is a shim to gofumpt — so `make fmt` (via `hack/fmt.sh`'s `gofmt -s -w`) and the linter now enforce the same formatting. No change to `hack/fmt.sh` is needed.

### `.golangci.yml`
- Enable **`bodyclose`** and **`prealloc`** linters (`unparam` was already enabled).
- Move `exclude-files` / `exclude-dirs` out of the deprecated `issues:` block into **`linters.exclusions.paths`** — the correct location in golangci-lint v2.
- Fix the over-escaped exclusion regex `generated.*\\.go` → `generated.*\.go`.
- Switch the formatter from **`gofmt` → `gofumpt`** and drop the now-unneeded `interface{}` → `any` rewrite rule (gofumpt performs this itself at go1.18+).

### Resulting formatting
- gofumpt reformatting applied across the affected Go files.
