### PR TITLE
Resolve Percona pg_tde (17.9-percona) addon version via hard-coded map

### DIFF
--- a/apis/storage/v1alpha1/snapshot_helpers.go
+++ b/apis/storage/v1alpha1/snapshot_helpers.go
@@ -181,6 +181,12 @@ func (s *Snapshot) GetSize() string {
 func GenerateSnapshotName(repoName, backupSession string) string {
 	backupSessionRegex := regexp.MustCompile("(.*)-([0-9]+)$")
 	subMatches := backupSessionRegex.FindStringSubmatch(backupSession)
+	// A BackupSession name does not always end in a numeric suffix (e.g. one
+	// created via generateName). Guard against a nil match instead of panicking
+	// on the index, and fall back to the full backupSession name as the suffix.
+	if len(subMatches) < 3 {
+		return meta.ValidNameWithPrefixNSuffix(repoName, backupSession, "")
+	}
 	return meta.ValidNameWithPrefixNSuffix(repoName, subMatches[1], subMatches[2])
 }
 

--- a/pkg/version.go
+++ b/pkg/version.go
@@ -41,6 +41,11 @@ var hardCodedMap = map[struct{ dbVersionRegex, funcNameRegex string }]string{
 	{"10.10.*", "mariadb-physical-(backup|restore)"}: "10.11.6-jammy",
 	{"10.11.*", "mariadb-physical-(backup|restore)"}: "10.11.6-jammy",
 	{"11.*.*", "mariadb-physical-(backup|restore)"}:  "11.1.3-jammy",
+	// Percona pg_tde distribution. The suffixed db version must be matched on the
+	// RAW dbVersion (before extractDBVersion strips the suffix), and the resolved
+	// value is used only as the ${DB_VERSION} image-tag substitution, so
+	// "17.9-percona" is intentionally kept OUT of every Function's availableVersions.
+	{`^17\.9-percona$`, "postgres-.*(backup|restore)"}: "17.9-percona",
 }
 
 func foundInHardCodedMap(funcName, dbVersion string) (bool, string) {
@@ -61,6 +66,12 @@ func foundInHardCodedMap(funcName, dbVersion string) (bool, string) {
 func FindAppropriateAddonVersion(addonVersions []string, dbVersion, funcName string) (string, error) {
 	if len(addonVersions) == 0 {
 		return "", fmt.Errorf("available list of addon-versions can't be empty")
+	}
+	// Match the hard-coded map against the RAW dbVersion first, so distribution
+	// suffixes (e.g. "17.9-percona") can be matched before extractDBVersion strips
+	// them down to a bare semver.
+	if found, av := foundInHardCodedMap(funcName, dbVersion); found {
+		return av, nil
 	}
 	dbVersion = extractDBVersion(dbVersion)
 	if found, av := foundInHardCodedMap(funcName, dbVersion); found {

--- a/pkg/version_test.go
+++ b/pkg/version_test.go
@@ -250,6 +250,27 @@ func TestFindAppropriateAddonVersion(t *testing.T) {
 			},
 			want: "17.2",
 		},
+		// Percona pg_tde. The suffixed db version is resolved via the hard-coded
+		// map against the RAW dbVersion, and "17.9-percona" is intentionally NOT
+		// present in availableVersions.
+		{
+			name: "pg-17.9-percona-backup",
+			args: args{
+				addonVersions: []string{"12.17", "14.10", "16.1", "17.2"},
+				dbVersion:     "17.9-percona",
+				funcName:      "postgres-backup",
+			},
+			want: "17.9-percona",
+		},
+		{
+			name: "pg-17.9-percona-restore",
+			args: args{
+				addonVersions: []string{"12.17", "14.10", "16.1", "17.2"},
+				dbVersion:     "17.9-percona",
+				funcName:      "postgres-restore",
+			},
+			want: "17.9-percona",
+		},
 		// No Addons
 		{
 			name: "no-addons",


### PR DESCRIPTION
## What

The Percona `pg_tde` Postgres distribution uses the db version `17.9-percona`. KubeStash needs to resolve a `${DB_VERSION}` addon/plugin image tag for it, but `FindAppropriateAddonVersion` ran `extractDBVersion` first, which stripped the `-percona` suffix down to `17.9` before the hard-coded map could ever see it. This makes it impossible to route `17.9-percona` to a distinct (Percona TDE) plugin image.

## Changes

- Run `foundInHardCodedMap` against the **RAW** `dbVersion` first, then fall back to the extracted bare-semver version so all existing entries keep matching exactly as before.
- Add `{^17\.9-percona$, postgres-.*(backup|restore)} -> 17.9-percona`. Per `pkg/resolver/task.go`, the resolved version is used **only** as the `${DB_VERSION}` image-tag substitution and is not checked against a Function's `availableVersions`, so `17.9-percona` is intentionally kept out of every Function's `availableVersions`.
- Add `version_test.go` cases for `postgres-backup` and `postgres-restore` resolving to `17.9-percona` while it is absent from `availableVersions`. All existing mongo/mysql/mariadb/postgres cases still pass.
- Harden `GenerateSnapshotName`: it indexed a regex submatch that is nil when a BackupSession name does not end in a numeric suffix (e.g. one created via `generateName`), causing a panic. It now guards the nil match and falls back to the full name.